### PR TITLE
⬆️ UPGRADE: Autoupdate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.2
+    rev: v2.37.3
     hooks:
       - id: pyupgrade
         args: [--py36-plus]
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.2
+    rev: v2.0.0
     hooks:
       - id: setup-cfg-fmt
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         additional_dependencies: [flake8-comprehensions, flake8-2020]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.960
     hooks:
       - id: mypy
         exclude: "^(docs|tests/dummy_packages)"
@@ -69,7 +69,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/myint/rstcheck
-    rev: "v6.0.0rc1"
+    rev: "v6.0.0rc3"
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.2 # Use the sha or tag you want to point at
+    rev: v2.7.1 # Use the sha or tag you want to point at
     hooks:
       - id: prettier
   - repo: https://github.com/asottile/setup-cfg-fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.0
+    rev: v2.32.1
     hooks:
       - id: pyupgrade
         args: [--py36-plus]
@@ -43,7 +43,7 @@ repos:
         additional_dependencies: [flake8-comprehensions, flake8-2020]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v0.950
     hooks:
       - id: mypy
         exclude: "^(docs|tests/dummy_packages)"
@@ -69,7 +69,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/myint/rstcheck
-    rev: "v5.0.0"
+    rev: "v6.0.0rc1"
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-ast
       - id: check-builtin-literals
@@ -11,7 +11,7 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.1
+    rev: v2.34.0
     hooks:
       - id: pyupgrade
         args: [--py36-plus]
@@ -43,7 +43,7 @@ repos:
         additional_dependencies: [flake8-comprehensions, flake8-2020]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.960
+    rev: v0.961
     hooks:
       - id: mypy
         exclude: "^(docs|tests/dummy_packages)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.1
+    rev: v2.37.2
     hooks:
       - id: pyupgrade
         args: [--py36-plus]
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.1
+    rev: v1.20.2
     hooks:
       - id: setup-cfg-fmt
 
@@ -43,7 +43,7 @@ repos:
         additional_dependencies: [flake8-comprehensions, flake8-2020]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.961
+    rev: v0.971
     hooks:
       - id: mypy
         exclude: "^(docs|tests/dummy_packages)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/myint/rstcheck
-    rev: "v6.0.0rc3"
+    rev: "v5.0.0"
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1 # Use the sha or tag you want to point at
+    rev: v3.0.0-alpha.0 # Use the sha or tag you want to point at
     hooks:
       - id: prettier
   - repo: https://github.com/asottile/setup-cfg-fmt
@@ -69,7 +69,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/myint/rstcheck
-    rev: "v6.0.0.post1"
+    rev: "v6.1.0"
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx]
@@ -87,7 +87,7 @@ repos:
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.1
     hooks:
       - id: codespell
         types: [file]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/python/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black
         language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.34.0
+    rev: v2.37.0
     hooks:
       - id: pyupgrade
         args: [--py36-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.0
+    rev: v2.37.1
     hooks:
       - id: pyupgrade
         args: [--py36-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,7 +95,7 @@ repos:
         args: [-L nnumber]
 
   - repo: https://github.com/asottile/yesqa
-    rev: v1.3.0
+    rev: v1.4.0
     hooks:
       - id: yesqa
         additional_dependencies: [flake8-docstrings]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/myint/rstcheck
-    rev: "v5.0.0"
+    rev: "v6.0.0.post1"
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx]

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,11 +16,6 @@ classifiers =
     Natural Language :: English
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
 keywords = verbose_version_info
 project_urls =
     Documentation=https://verbose-version-info.readthedocs.io


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/s-weigand/verbose-version-info/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>pip install pre-commit</em></summary>

```Shell
Collecting pre-commit
  Downloading pre_commit-2.19.0-py2.py3-none-any.whl (199 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 199.3/199.3 kB 12.7 MB/s eta 0:00:00
Collecting nodeenv>=0.11.1
  Downloading nodeenv-1.6.0-py2.py3-none-any.whl (21 kB)
Collecting toml
  Downloading toml-0.10.2-py2.py3-none-any.whl (16 kB)
Collecting virtualenv>=20.0.8
  Downloading virtualenv-20.14.1-py2.py3-none-any.whl (8.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.8/8.8 MB 77.3 MB/s eta 0:00:00
Collecting identify>=1.0.0
  Downloading identify-2.5.1-py2.py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.6/98.6 kB 32.0 MB/s eta 0:00:00
Collecting pyyaml>=5.1
  Downloading PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (682 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 682.2/682.2 kB 85.1 MB/s eta 0:00:00
Collecting cfgv>=2.0.0
  Downloading cfgv-3.3.1-py2.py3-none-any.whl (7.3 kB)
Collecting six<2,>=1.9.0
  Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting distlib<1,>=0.3.1
  Downloading distlib-0.3.4-py2.py3-none-any.whl (461 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 461.2/461.2 kB 64.5 MB/s eta 0:00:00
Collecting platformdirs<3,>=2
  Downloading platformdirs-2.5.2-py3-none-any.whl (14 kB)
Collecting filelock<4,>=3.2
  Downloading filelock-3.7.0-py3-none-any.whl (10 kB)
Installing collected packages: nodeenv, distlib, toml, six, pyyaml, platformdirs, identify, filelock, cfgv, virtualenv, pre-commit
Successfully installed cfgv-3.3.1 distlib-0.3.4 filelock-3.7.0 identify-2.5.1 nodeenv-1.6.0 platformdirs-2.5.2 pre-commit-2.19.0 pyyaml-6.0 six-1.16.0 toml-0.10.2 virtualenv-20.14.1
```

### stderr:

```Shell
WARNING: There was an error checking the latest version of pip.
```

</details>
<details>
<summary><em>pre-commit autoupdate || (exit 0);</em></summary>

```Shell
Updating https://github.com/pre-commit/pre-commit-hooks ... [INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
already up to date.
Updating https://github.com/asottile/pyupgrade ... [INFO] Initializing environment for https://github.com/asottile/pyupgrade.
updating v2.32.0 -> v2.32.1.
Updating https://github.com/PyCQA/isort ... [INFO] Initializing environment for https://github.com/PyCQA/isort.
already up to date.
Updating https://github.com/python/black ... [INFO] Initializing environment for https://github.com/python/black.
already up to date.
Updating https://github.com/pre-commit/mirrors-prettier ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier.
already up to date.
Updating https://github.com/asottile/setup-cfg-fmt ... [INFO] Initializing environment for https://github.com/asottile/setup-cfg-fmt.
already up to date.
Updating https://gitlab.com/pycqa/flake8 ... [INFO] Initializing environment for https://gitlab.com/pycqa/flake8.
already up to date.
Updating https://github.com/pre-commit/mirrors-mypy ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy.
updating v0.942 -> v0.950.
Updating https://github.com/PyCQA/pydocstyle ... [INFO] Initializing environment for https://github.com/PyCQA/pydocstyle.
already up to date.
Updating https://github.com/terrencepreilly/darglint ... [INFO] Initializing environment for https://github.com/terrencepreilly/darglint.
already up to date.
Updating https://github.com/econchick/interrogate ... [INFO] Initializing environment for https://github.com/econchick/interrogate.
already up to date.
Updating https://github.com/myint/rstcheck ... [INFO] Initializing environment for https://github.com/myint/rstcheck.
updating v5.0.0 -> v6.0.0rc1.
Updating https://github.com/pre-commit/pygrep-hooks ... [INFO] Initializing environment for https://github.com/pre-commit/pygrep-hooks.
already up to date.
Updating https://github.com/codespell-project/codespell ... [INFO] Initializing environment for https://github.com/codespell-project/codespell.
already up to date.
Updating https://github.com/asottile/yesqa ... [INFO] Initializing environment for https://github.com/asottile/yesqa.
already up to date.
Updating https://github.com/econchick/interrogate ... already up to date.
```



</details>
<details>
<summary><em>pre-commit run -a || (exit 0);</em></summary>

```Shell
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier:prettier@2.6.2.
[INFO] Initializing environment for https://gitlab.com/pycqa/flake8:flake8-2020,flake8-comprehensions.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy:types-all.
[INFO] Initializing environment for https://github.com/myint/rstcheck:sphinx.
[INFO] Initializing environment for https://github.com/asottile/yesqa:flake8-docstrings.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/python/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/setup-cfg-fmt.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://gitlab.com/pycqa/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/pydocstyle.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/terrencepreilly/darglint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/econchick/interrogate.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/myint/rstcheck.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/codespell-project/codespell.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/yesqa.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
check python ast.........................................................Passed
check builtin type constructor use.......................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
debug statements (python)................................................Passed
fix python encoding pragma...............................................Passed
pyupgrade................................................................Passed
isort....................................................................Passed
black....................................................................Passed
prettier.................................................................Passed
setup-cfg-fmt............................................................Passed
flake8...................................................................Passed
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

verbose_version_info/resource_finders.py:139: error: "PackageMetadata" has no attribute "get"  [attr-defined]
Found 1 error in 1 file (checked 18 source files)

pydocstyle...............................................................Passed
darglint.................................................................Passed
interrogate..............................................................Passed
rstcheck.................................................................Failed
- hook id: rstcheck
- exit code: 1

WARNING:rstcheck.checker:Skipping unparsable message: 'Trying "autosummary" as canonical directive name.'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '.. autosummary::'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :toctree: api'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :recursive:'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '    verbose_version_info'.
docs/api_docs.rst:7: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/api_docs.rst:7: (ERROR/3) Unknown directive type "autosummary".
WARNING:rstcheck.checker:Skipping unparsable message: 'Trying "autosummary" as canonical directive name.'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '.. autosummary::'.
WARNING:rstcheck.checker:Skipping unparsable message: '  :toctree: {{ name }}'.
WARNING:rstcheck.checker:Skipping unparsable message: '  :recursive:'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '  {% for item in modules %}'.
WARNING:rstcheck.checker:Skipping unparsable message: '    {{ item }}'.
WARNING:rstcheck.checker:Skipping unparsable message: '  {%- endfor %}'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: 'Trying "autosummary" as canonical directive name.'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '.. autosummary::'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :toctree: {{ name }}'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '    {% for item in attributes %}'.
WARNING:rstcheck.checker:Skipping unparsable message: '        {{ item }}'.
WARNING:rstcheck.checker:Skipping unparsable message: '    {%- endfor %}'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: 'Trying "autosummary" as canonical directive name.'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '.. autosummary::'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :toctree: {{ name }}/functions'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :nosignatures:'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '    {% for item in functions %}'.
WARNING:rstcheck.checker:Skipping unparsable message: '      {{ item }}'.
WARNING:rstcheck.checker:Skipping unparsable message: '    {%- endfor %}'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: 'Trying "autosummary" as canonical directive name.'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '.. autosummary::'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :toctree: {{ name }}/classes'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :nosignatures:'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '    {% for item in classes %}'.
WARNING:rstcheck.checker:Skipping unparsable message: '      {{ item }}'.
WARNING:rstcheck.checker:Skipping unparsable message: '    {%- endfor %}'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: 'Trying "autosummary" as canonical directive name.'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '.. autosummary::'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :toctree: {{ name }}/exceptions'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :nosignatures:'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '    {% for item in exceptions %}'.
WARNING:rstcheck.checker:Skipping unparsable message: '        {{ item }}'.
WARNING:rstcheck.checker:Skipping unparsable message: '    {%- endfor %}'.
docs/_templates/autosummary/module.rst:14: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:14: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:31: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:31: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:50: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:50: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:70: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:70: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:91: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:91: (ERROR/3) Unknown directive type "autosummary".

rst ``code`` is two backticks............................................Passed
check blanket noqa.......................................................Passed
check blanket type ignore................................................Passed
type annotations not comments............................................Passed
rst directives end with two colons.......................................Passed
rst ``inline code`` next to normal text..................................Passed
codespell................................................................Passed
Strip unnecessary `# noqa`s..............................................Passed
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- .pre-commit-config.yaml

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)