### PR TITLE
⬆️ UPGRADE: Autoupdate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,17 +27,24 @@ repos:
       - id: black
         language_version: python3
 
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.4.0
+    hooks:
+      - id: yesqa
+        additional_dependencies: [flake8-docstrings]
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.0-alpha.0 # Use the sha or tag you want to point at
     hooks:
       - id: prettier
+
   - repo: https://github.com/asottile/setup-cfg-fmt
     rev: v2.0.0
     hooks:
       - id: setup-cfg-fmt
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies: [flake8-comprehensions, flake8-2020]
@@ -93,9 +100,3 @@ repos:
         types: [file]
         types_or: [python, pyi, markdown, rst, jupyter]
         args: [-L nnumber]
-
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.4.0
-    hooks:
-      - id: yesqa
-        additional_dependencies: [flake8-docstrings]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,13 +99,3 @@ repos:
     hooks:
       - id: yesqa
         additional_dependencies: [flake8-docstrings]
-
-  - repo: https://github.com/econchick/interrogate
-    rev: 1.5.0
-    hooks:
-      - id: interrogate
-        name: Update interrogate badge
-        args:
-          [-v, --config=pyproject.toml, -g, docs/_static/interrogate_badge.svg]
-        pass_filenames: false
-        stages: [push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-ast
       - id: check-builtin-literals
@@ -11,7 +11,7 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.0
+    rev: v2.37.3
     hooks:
       - id: pyupgrade
         args: [--py36-plus]
@@ -22,17 +22,17 @@ repos:
       - id: isort
 
   - repo: https://github.com/python/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black
         language_version: python3
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.2 # Use the sha or tag you want to point at
+    rev: v3.0.0-alpha.0 # Use the sha or tag you want to point at
     hooks:
       - id: prettier
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.1
+    rev: v2.0.0
     hooks:
       - id: setup-cfg-fmt
 
@@ -43,7 +43,7 @@ repos:
         additional_dependencies: [flake8-comprehensions, flake8-2020]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v0.971
     hooks:
       - id: mypy
         exclude: "^(docs|tests/dummy_packages)"
@@ -69,7 +69,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/myint/rstcheck
-    rev: "v5.0.0"
+    rev: "v6.1.0"
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx]
@@ -87,7 +87,7 @@ repos:
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.1
     hooks:
       - id: codespell
         types: [file]
@@ -95,7 +95,7 @@ repos:
         args: [-L nnumber]
 
   - repo: https://github.com/asottile/yesqa
-    rev: v1.3.0
+    rev: v1.4.0
     hooks:
       - id: yesqa
         additional_dependencies: [flake8-docstrings]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,6 +80,7 @@ repos:
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx]
+        exclude: "^(docs/_templates)"
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,11 +16,6 @@ classifiers =
     Natural Language :: English
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
 keywords = verbose_version_info
 project_urls =
     Documentation=https://verbose-version-info.readthedocs.io

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ convention = numpy
 test = pytest
 
 [rstcheck]
-ignore_directives = autoattribute,autoclass,autoexception,autofunction,automethod,automodule,highlight
+ignore_directives = highlight,autosummary
 
 [mypy]
 show_error_codes = True

--- a/verbose_version_info/resource_finders.py
+++ b/verbose_version_info/resource_finders.py
@@ -136,7 +136,9 @@ def egg_link_lines(distribution_name: str) -> Optional[List[str]]:
     --------
     find_editable_install_basepath
     """
-    distribution_name = distribution(distribution_name).metadata.get("name")
+    distribution_name = distribution(distribution_name).metadata.get(  # type:ignore[attr-defined]
+        "name"
+    )
     for path_item in sys.path:
         egg_link = os.path.join(path_item, f"{distribution_name}.egg-link")
         if os.path.isfile(egg_link):

--- a/verbose_version_info/settings.py
+++ b/verbose_version_info/settings.py
@@ -1,4 +1,4 @@
-"""Module containing all seetings related functionalities."""
+"""Module containing all settings related functionalities."""
 from copy import copy
 
 DEFAULT_VCS_SETTINGS = {"warn_dirty": True}


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/s-weigand/verbose-version-info/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>pip install pre-commit</em></summary>

```Shell
Collecting pre-commit
  Downloading pre_commit-2.20.0-py2.py3-none-any.whl (199 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 199.5/199.5 kB 8.2 MB/s eta 0:00:00
Collecting pyyaml>=5.1
  Downloading PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (596 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 596.3/596.3 kB 35.2 MB/s eta 0:00:00
Collecting toml
  Downloading toml-0.10.2-py2.py3-none-any.whl (16 kB)
Collecting cfgv>=2.0.0
  Downloading cfgv-3.3.1-py2.py3-none-any.whl (7.3 kB)
Collecting importlib-metadata
  Downloading importlib_metadata-4.12.0-py3-none-any.whl (21 kB)
Collecting identify>=1.0.0
  Downloading identify-2.5.3-py2.py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.7/98.7 kB 21.9 MB/s eta 0:00:00
Collecting virtualenv>=20.0.8
  Downloading virtualenv-20.16.3-py2.py3-none-any.whl (8.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.8/8.8 MB 77.3 MB/s eta 0:00:00
Collecting nodeenv>=0.11.1
  Downloading nodeenv-1.7.0-py2.py3-none-any.whl (21 kB)
Requirement already satisfied: setuptools in /opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages (from nodeenv>=0.11.1->pre-commit) (47.1.0)
Collecting filelock<4,>=3.4.1
  Downloading filelock-3.8.0-py3-none-any.whl (10 kB)
Collecting distlib<1,>=0.3.5
  Downloading distlib-0.3.6-py2.py3-none-any.whl (468 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 468.5/468.5 kB 55.2 MB/s eta 0:00:00
Collecting platformdirs<3,>=2.4
  Downloading platformdirs-2.5.2-py3-none-any.whl (14 kB)
Collecting typing-extensions>=3.6.4
  Downloading typing_extensions-4.3.0-py3-none-any.whl (25 kB)
Collecting zipp>=0.5
  Downloading zipp-3.8.1-py3-none-any.whl (5.6 kB)
Installing collected packages: distlib, zipp, typing-extensions, toml, pyyaml, platformdirs, nodeenv, identify, filelock, cfgv, importlib-metadata, virtualenv, pre-commit
Successfully installed cfgv-3.3.1 distlib-0.3.6 filelock-3.8.0 identify-2.5.3 importlib-metadata-4.12.0 nodeenv-1.7.0 platformdirs-2.5.2 pre-commit-2.20.0 pyyaml-6.0 toml-0.10.2 typing-extensions-4.3.0 virtualenv-20.16.3 zipp-3.8.1
```



</details>
<details>
<summary><em>pre-commit autoupdate || (exit 0);</em></summary>

```Shell
Updating https://github.com/pre-commit/pre-commit-hooks ... updating v4.2.0 -> v4.3.0.
Updating https://github.com/asottile/pyupgrade ... [INFO] Initializing environment for https://github.com/asottile/pyupgrade.
updating v2.32.0 -> v2.37.3.
Updating https://github.com/PyCQA/isort ... already up to date.
Updating https://github.com/python/black ... [INFO] Initializing environment for https://github.com/python/black.
updating 22.3.0 -> 22.6.0.
Updating https://github.com/pre-commit/mirrors-prettier ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier.
updating v2.6.2 -> v3.0.0-alpha.0.
Updating https://github.com/asottile/setup-cfg-fmt ... [INFO] Initializing environment for https://github.com/asottile/setup-cfg-fmt.
updating v1.20.1 -> v2.0.0.
Updating https://gitlab.com/pycqa/flake8 ... already up to date.
Updating https://github.com/pre-commit/mirrors-mypy ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy.
updating v0.942 -> v0.971.
Updating https://github.com/PyCQA/pydocstyle ... already up to date.
Updating https://github.com/terrencepreilly/darglint ... already up to date.
Updating https://github.com/econchick/interrogate ... already up to date.
Updating https://github.com/myint/rstcheck ... [INFO] Initializing environment for https://github.com/myint/rstcheck.
updating v5.0.0 -> v6.1.0.
Updating https://github.com/pre-commit/pygrep-hooks ... already up to date.
Updating https://github.com/codespell-project/codespell ... [INFO] Initializing environment for https://github.com/codespell-project/codespell.
updating v2.1.0 -> v2.2.1.
Updating https://github.com/asottile/yesqa ... [INFO] Initializing environment for https://github.com/asottile/yesqa.
updating v1.3.0 -> v1.4.0.
Updating https://github.com/econchick/interrogate ... already up to date.
```



</details>
<details>
<summary><em>pre-commit run -a || (exit 0);</em></summary>

```Shell
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier:prettier@3.0.0-alpha.0.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy:types-all.
[INFO] Initializing environment for https://github.com/myint/rstcheck:sphinx.
[INFO] Initializing environment for https://github.com/asottile/yesqa:flake8-docstrings.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/python/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/setup-cfg-fmt.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://gitlab.com/pycqa/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/pydocstyle.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/terrencepreilly/darglint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/econchick/interrogate.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/myint/rstcheck.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/codespell-project/codespell.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/yesqa.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
check python ast.........................................................Passed
check builtin type constructor use.......................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
debug statements (python)................................................Passed
fix python encoding pragma...............................................Passed
pyupgrade................................................................Passed
isort....................................................................Passed
black....................................................................Passed
prettier.................................................................Passed
setup-cfg-fmt............................................................Failed
- hook id: setup-cfg-fmt
- exit code: 1
- files were modified by this hook

Rewriting setup.cfg

flake8...................................................................Passed
mypy.....................................................................Passed
pydocstyle...............................................................Passed
darglint.................................................................Passed
interrogate..............................................................Passed
rstcheck.................................................................Failed
- hook id: rstcheck
- exit code: 1

CRITICAL:rstcheck_core.checker:An `AttributeError` error occured. This is most propably due to a code block directive (code/code-block/sourcecode) without a specified language. This may result in a false negative for source: 'docs/contributing.rst'. See https://rstcheck-core.readthedocs.io/en/latest/faq/#code-blocks-without-language-sphinx for more information.
docs/api_docs.rst:7: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/api_docs.rst:7: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:14: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:14: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:31: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:31: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:50: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:50: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:70: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:70: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:91: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:91: (ERROR/3) Unknown directive type "autosummary".
Error! Issues detected.

rst ``code`` is two backticks............................................Passed
check blanket noqa.......................................................Passed
check blanket type ignore................................................Passed
type annotations not comments............................................Passed
rst directives end with two colons.......................................Passed
rst ``inline code`` next to normal text..................................Passed
codespell................................................................Failed
- hook id: codespell
- exit code: 65

verbose_version_info/settings.py:1: seetings ==> settings

Strip unnecessary `# noqa`s..............................................Passed
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- .pre-commit-config.yaml
- setup.cfg

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)