### PR TITLE
🚧 Fix CI and update config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Check out repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-ast
       - id: check-builtin-literals
@@ -11,18 +11,18 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.1.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args: [--py36-plus]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
 
   - repo: https://github.com/python/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
         language_version: python3
@@ -34,30 +34,30 @@ repos:
         additional_dependencies: [flake8-docstrings]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.3 # Use the sha or tag you want to point at
+    rev: v3.0.0-alpha.4 # Use the sha or tag you want to point at
     hooks:
       - id: prettier
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.1.0
+    rev: v2.2.0
     hooks:
       - id: setup-cfg-fmt
 
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies: [flake8-comprehensions, flake8-2020]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v0.991
     hooks:
       - id: mypy
         exclude: "^(docs|tests/dummy_packages)"
         additional_dependencies: [types-all]
 
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.1.1
+    rev: 6.2.2
     hooks:
       - id: pydocstyle
         exclude: "^(docs|tests|setup.py)"
@@ -76,7 +76,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/myint/rstcheck
-    rev: "v6.1.0"
+    rev: "v6.1.1"
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
     rev: v2.2.0
     hooks:
       - id: setup-cfg-fmt
+        args: ["--include-version-classifiers"]
 
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -104,7 +104,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.md.
-3. The pull request should work for Python 3.5, 3.6, 3.7 and 3.8, and for PyPy. Check
+3. The pull request should work for Python 3.7, 3.8, 3.9, 3.10 and 3.11, and for PyPy. Check
    https://github.com/s-weigand/verbose-version-info/actions
    and make sure that the tests pass for all supported Python versions.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ project_urls =
 packages = find:
 install_requires =
     importlib-metadata>=3.4.0;python_version < '3.8'
-python_requires = >=3.6.1
+python_requires = >=3.7
 include_package_data = True
 setup_requires =
     setuptools>=41.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,11 @@ classifiers =
     Natural Language :: English
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 keywords = verbose_version_info
 project_urls =
     Documentation=https://verbose-version-info.readthedocs.io

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.4.0
 skip_missing_interpreters=true
-envlist = py{36,37,38,39}, pre-commit, docs, docs-links
+envlist = py{37,38,39,310,311}, pre-commit, docs, docs-links
 
 [pytest]
 addopts = --cov=verbose_version_info --cov-report term --cov-report xml --cov-report html --cov-config=pyproject.toml


### PR DESCRIPTION
This is a maintenance PR to fix the pre-commit CI and bring the project up to speed with changes in tool and python EOL.

**Change Summary**:
- [🚇⬆️ Upgrad python version for pre-commit to 3.8 (required by flake8>=6)](https://github.com/s-weigand/verbose-version-info/commit/28de090f70c1d64a045968a41f9a5c5289f948e3)
- [🚧 Drop python 3.6 support](https://github.com/s-weigand/verbose-version-info/commit/13ae88f632663c3f5a4d6603b75b5dc9061a467b)
- [⬆️ UPGRADE: Autoupdate pre-commit config](https://github.com/s-weigand/verbose-version-info/commit/c567efe3d6946d002bc67e59bd0a425d4a5d66b5)
- [🔧 Add '--include-version-classifiers' to setup-cfg-fmt](https://github.com/s-weigand/verbose-version-info/commit/3f1cef45b6a5fbdf9df3e06956c87bfdba79ce3b)