### PR TITLE
⬆️ UPGRADE: Autoupdate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.2
+    rev: v3.4.0
     hooks:
       - id: pyupgrade
         args: [--py36-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
       - id: prettier
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.2.0
+    rev: v2.3.0
     hooks:
       - id: setup-cfg-fmt
         args: ["--include-version-classifiers"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         additional_dependencies: [flake8-comprehensions, flake8-2020]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.2.0
+    rev: v1.3.0
     hooks:
       - id: mypy
         exclude: "^(docs|tests/dummy_packages)"

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ url = https://github.com/s-weigand/verbose-version-info
 author = Sebastian Weigand
 author_email = s.weigand.phy@gmail.com
 license = Apache Software License 2.0
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 2 - Pre-Alpha
     Intended Audience :: Developers


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/s-weigand/verbose-version-info/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>pip install pre-commit</em></summary>

```Shell
Collecting pre-commit
  Downloading pre_commit-3.3.1-py2.py3-none-any.whl (202 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 202.5/202.5 kB 4.4 MB/s eta 0:00:00
Collecting cfgv>=2.0.0 (from pre-commit)
  Downloading cfgv-3.3.1-py2.py3-none-any.whl (7.3 kB)
Collecting identify>=1.0.0 (from pre-commit)
  Downloading identify-2.5.24-py2.py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.8/98.8 kB 8.4 MB/s eta 0:00:00
Collecting nodeenv>=0.11.1 (from pre-commit)
  Downloading nodeenv-1.7.0-py2.py3-none-any.whl (21 kB)
Collecting pyyaml>=5.1 (from pre-commit)
  Downloading PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (701 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 701.2/701.2 kB 10.6 MB/s eta 0:00:00
Collecting virtualenv>=20.10.0 (from pre-commit)
  Downloading virtualenv-20.23.0-py3-none-any.whl (3.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.3/3.3 MB 19.6 MB/s eta 0:00:00
Requirement already satisfied: setuptools in /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages (from nodeenv>=0.11.1->pre-commit) (56.0.0)
Collecting distlib<1,>=0.3.6 (from virtualenv>=20.10.0->pre-commit)
  Downloading distlib-0.3.6-py2.py3-none-any.whl (468 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 468.5/468.5 kB 27.3 MB/s eta 0:00:00
Collecting filelock<4,>=3.11 (from virtualenv>=20.10.0->pre-commit)
  Downloading filelock-3.12.0-py3-none-any.whl (10 kB)
Collecting platformdirs<4,>=3.2 (from virtualenv>=20.10.0->pre-commit)
  Downloading platformdirs-3.5.0-py3-none-any.whl (15 kB)
Installing collected packages: distlib, pyyaml, platformdirs, nodeenv, identify, filelock, cfgv, virtualenv, pre-commit
Successfully installed cfgv-3.3.1 distlib-0.3.6 filelock-3.12.0 identify-2.5.24 nodeenv-1.7.0 platformdirs-3.5.0 pre-commit-3.3.1 pyyaml-6.0 virtualenv-20.23.0
```

### stderr:

```Shell
[notice] A new release of pip is available: 22.0.4 -> 23.1.2
[notice] To update, run: pip install --upgrade pip
```

</details>
<details>
<summary><em>pre-commit autoupdate || (exit 0);</em></summary>

```Shell
[https://github.com/pre-commit/pre-commit-hooks] already up to date!
[https://github.com/asottile/pyupgrade] updating v3.3.2 -> v3.4.0
[https://github.com/PyCQA/isort] already up to date!
[https://github.com/python/black] already up to date!
[https://github.com/asottile/yesqa] already up to date!
[https://github.com/pre-commit/mirrors-prettier] already up to date!
[https://github.com/asottile/setup-cfg-fmt] already up to date!
[https://github.com/pycqa/flake8] already up to date!
[https://github.com/pre-commit/mirrors-mypy] already up to date!
[https://github.com/PyCQA/pydocstyle] already up to date!
[https://github.com/terrencepreilly/darglint] already up to date!
[https://github.com/econchick/interrogate] already up to date!
[https://github.com/myint/rstcheck] already up to date!
[https://github.com/pre-commit/pygrep-hooks] already up to date!
[https://github.com/codespell-project/codespell] already up to date!
```



</details>
<details>
<summary><em>pre-commit run -a || (exit 0);</em></summary>

```Shell
[INFO] Initializing environment for https://github.com/asottile/pyupgrade.
[INFO] Initializing environment for https://github.com/python/black.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier:prettier@3.0.0-alpha.9-for-vscode.
[INFO] Initializing environment for https://github.com/pycqa/flake8:flake8-comprehensions,flake8-2020.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy:types-all.
[INFO] Initializing environment for https://github.com/myint/rstcheck.
[INFO] Initializing environment for https://github.com/myint/rstcheck:sphinx.
[INFO] Initializing environment for https://github.com/codespell-project/codespell.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/python/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/yesqa.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/setup-cfg-fmt.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pycqa/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/pydocstyle.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/terrencepreilly/darglint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/econchick/interrogate.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/myint/rstcheck.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/codespell-project/codespell.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
check python ast.........................................................Passed
check builtin type constructor use.......................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
debug statements (python)................................................Passed
fix python encoding pragma...............................................Passed
pyupgrade................................................................Passed
isort....................................................................Passed
black....................................................................Passed
Strip unnecessary `# noqa`s..............................................Passed
prettier.................................................................Passed
setup-cfg-fmt............................................................Passed
flake8...................................................................Passed
mypy.....................................................................Passed
pydocstyle...............................................................Passed
darglint.................................................................Passed
interrogate..............................................................Passed
rstcheck.................................................................Passed
rst ``code`` is two backticks............................................Passed
check blanket noqa.......................................................Passed
check blanket type ignore................................................Passed
type annotations not comments............................................Passed
rst directives end with two colons.......................................Passed
rst ``inline code`` next to normal text..................................Passed
codespell................................................................Passed
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- .pre-commit-config.yaml

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)